### PR TITLE
Use 0-based indexing, and store the total size

### DIFF
--- a/src/lib/tools/index.rs
+++ b/src/lib/tools/index.rs
@@ -62,23 +62,21 @@ pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
             + 1 // newline
         };
 
-        num_records += 1;
-
         if num_records % opts.nth == 0 {
             index_writer.write_u64::<LittleEndian>(num_records)?;
             index_writer.write_u64::<LittleEndian>(total_bytes)?;
         }
 
+        num_records += 1;
         total_bytes += num_bytes as u64;
 
         if let Some(ref mut writer) = fastq_writer {
             rec.write(writer)?;
         }
     }
-    if num_records % opts.nth != 0 {
-        index_writer.write_u64::<LittleEndian>(num_records)?;
-        index_writer.write_u64::<LittleEndian>(total_bytes)?;
-    }
+
+    index_writer.write_u64::<LittleEndian>(num_records)?;
+    index_writer.write_u64::<LittleEndian>(total_bytes)?;
 
     Ok(())
 }


### PR DESCRIPTION
- Use 0-based indexing.
- Output a final record with the total file size.

### Test data

```console
$ pigz -cd foo.fastq.gz
@hi
ACGT
+
IIII
@bye
TTTT
+
IIII
$ pigz -cd foo.fastq.gz | bin/fqme index -n1 --output=foo.fastq.gz.fqi >/dev/null
```

### Before

```console
$ xxd foo.fastq.gz.fqi         
00000000: 0100 0000 0000 0000 0000 0000 0000 0000  ................
00000010: 0200 0000 0000 0000 1000 0000 0000 0000  ................
```

### After

```console
$ xxd foo.fastq.gz.fqi         
00000000: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00000010: 0100 0000 0000 0000 1000 0000 0000 0000  ................
00000020: 0200 0000 0000 0000 2100 0000 0000 0000  ........!.......
```
