### PR TITLE
refactor: replace .unwrap() with Result types in library code

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Pre-commit hook to run the same checks as CI
+# Install with: cp scripts/pre-commit .git/hooks/ && chmod +x .git/hooks/pre-commit
+
+set -e
+
+echo "Running pre-commit checks..."
+
+# Run cargo fmt check
+echo "Checking formatting..."
+if ! cargo fmt -- --check; then
+    echo ""
+    echo "ERROR: Formatting check failed. Run 'cargo fmt' to fix."
+    exit 1
+fi
+
+# Run cargo clippy with the same flags as CI
+# Using stable toolchain to match CI behavior
+echo "Running clippy..."
+if rustup run stable rustc --version >/dev/null 2>&1; then
+    if ! cargo +stable clippy --all-features -- -D warnings; then
+        echo ""
+        echo "ERROR: Clippy check failed. Fix the warnings above."
+        exit 1
+    fi
+else
+    echo "Note: stable toolchain not found, using default"
+    if ! cargo clippy --all-features -- -D warnings; then
+        echo ""
+        echo "ERROR: Clippy check failed. Fix the warnings above."
+        exit 1
+    fi
+fi
+
+echo "All pre-commit checks passed!"

--- a/src/lib/tools/extract.rs
+++ b/src/lib/tools/extract.rs
@@ -56,7 +56,7 @@ pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
     let gzi_path = format!("{}.{}", opts.input.to_string_lossy(), "gzi");
 
     // Read the FASTQ index
-    let fastq_index = FastqIndex::read(Path::new(&fqi_path));
+    let fastq_index = FastqIndex::read(Path::new(&fqi_path))?;
     let fqi_range = match fastq_index.range(start, end) {
         Some(range) => range,
         None => return Ok(()),
@@ -69,7 +69,7 @@ pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
     // println!("    bgzip -b {} -s {} {:?}", fqi_range.start_byte, fqi_range.num_bytes(), opts.input);
 
     // Read the BGZF index and find the compressed offset
-    let gzi = BgzfIndex::from(gzi_path);
+    let gzi = BgzfIndex::from(&gzi_path)?;
     let mut start_entry: BgzfIndexOffset = gzi.entries[0];
     let mut num_blocks: usize = 0;
     for entry in gzi.entries {
@@ -84,7 +84,7 @@ pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
     }
 
     // Build a BgzfReader starting at the next FASTQ record
-    let file = File::open(opts.input.clone()).unwrap();
+    let file = File::open(&opts.input)?;
     let bgzf_reader: BgzfReader =
         BgzfReader::new(file, fqi_range.start_byte, start_entry, num_blocks);
 

--- a/src/lib/tools/index.rs
+++ b/src/lib/tools/index.rs
@@ -41,7 +41,7 @@ pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
         }
     };
 
-    FastqIndex::from(reader, opts.nth, &mut fastq_writer).write(opts.output.as_path());
+    FastqIndex::from(reader, opts.nth, &mut fastq_writer)?.write(opts.output.as_path())?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Replace panic-on-error `.unwrap()` calls with proper error handling using Result types in all public library functions.

## Changes

| Function | Old Return | New Return |
|----------|------------|------------|
| `FastqIndex::read()` | `FastqIndex` | `io::Result<FastqIndex>` |
| `FastqIndex::from()` | `FastqIndex` | `io::Result<FastqIndex>` |
| `FastqIndex::write()` | `()` | `io::Result<()>` |
| `BgzfIndex::from()` | `BgzfIndex` | `io::Result<BgzfIndex>` |

## Why This Matters

- Library code should never panic on errors (corrupted files, missing files, I/O errors)
- Callers can now handle errors gracefully instead of crashing
- Makes the library safe to embed in other applications
- Follows Rust best practices for error handling

## Remaining `.unwrap()` calls

Some internal unwraps remain in `BgzfReader` (private struct) for:
- BGZF header validation
- Block decompression

These are candidates for future cleanup but don't affect the public API.

## Test plan

- [x] All 8 unit tests pass
- [x] `cargo clippy` passes
- [x] CLI commands still work (errors now propagated via `?`)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pre-commit hook that runs formatting and lint checks locally before commits.

* **Bug Fixes**
  * Replaced panic-style failures with propagated error handling for file I/O and parsing, improving reliability and clearer error reporting.

* **Tests**
  * Updated tests to accommodate the new error-returning behavior in affected routines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->