### PR TITLE
fix: add bounds check for empty BgzfIndex entries

### DIFF
--- a/src/lib/tools/extract.rs
+++ b/src/lib/tools/extract.rs
@@ -70,6 +70,7 @@ pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
 
     // Read the BGZF index and find the compressed offset
     let gzi = BgzfIndex::from(&gzi_path)?;
+    ensure!(!gzi.entries.is_empty(), "GZI index file is empty or corrupted: {}", gzi_path);
     let mut start_entry: BgzfIndexOffset = gzi.entries[0];
     let mut num_blocks: usize = 0;
     for entry in gzi.entries {


### PR DESCRIPTION
## Summary

Add defensive bounds check before accessing `gzi.entries[0]` to prevent index-out-of-bounds panic if the GZI index file is corrupted or empty.

## Change

```rust
// Before
let gzi = BgzfIndex::from(gzi_path);
let mut start_entry: BgzfIndexOffset = gzi.entries[0];  // PANIC if empty!

// After  
let gzi = BgzfIndex::from(gzi_path.clone());
ensure!(!gzi.entries.is_empty(), "GZI index file is empty or corrupted: {}", gzi_path);
let mut start_entry: BgzfIndexOffset = gzi.entries[0];  // Safe
```

## Why This Matters

- Prevents unhelpful panic message for corrupted files
- Returns descriptive error message with file path
- Improves user experience when debugging file issues

## Note

The current `BgzfIndex::from()` implementation always adds a synthetic zero entry, so this check is primarily defensive against future code changes or edge cases with corrupted files.

## Test plan

- [x] All 8 unit tests pass
- [x] `cargo clippy` passes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect and report empty or corrupted index files with descriptive error messages, preventing downstream errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->