### PR TITLE
Fix FASTQ byte calculation to handle + line comments

### DIFF
--- a/src/lib/tools/index.rs
+++ b/src/lib/tools/index.rs
@@ -28,20 +28,15 @@ pub struct Opts {
 // Run index
 #[allow(clippy::too_many_lines)]
 pub fn run(opts: &Opts) -> Result<(), anyhow::Error> {
-    let reader = {
-        let reader = BufReader::with_capacity(BUFFERSIZE, io::stdin());
-        seq_io::fastq::Reader::new(reader).into_records()
+    let reader = BufReader::with_capacity(BUFFERSIZE, io::stdin());
+
+    let mut fastq_writer = if opts.no_stdout {
+        None
+    } else {
+        Some(BufWriter::with_capacity(BUFFERSIZE, io::stdout()))
     };
 
-    let mut fastq_writer = {
-        if opts.no_stdout {
-            None
-        } else {
-            Some(BufWriter::with_capacity(BUFFERSIZE, io::stdout()))
-        }
-    };
-
-    FastqIndex::from(reader, opts.nth, &mut fastq_writer)?.write(opts.output.as_path())?;
+    FastqIndex::from_reader(reader, opts.nth, &mut fastq_writer)?.write(opts.output.as_path())?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Fixes #17 - FASTQ byte calculation now correctly handles comments on the + separator line
- Add `ByteCountingWriter` to measure exact record sizes using `write_unchanged()`
- Deprecate `FastqIndex::from()` in favor of `from_reader()` which uses accurate byte tracking
- Add tests verifying correct byte counting with + line comments

## Problem

The previous implementation computed byte sizes from record fields:
```rust
let num_bytes = 1 // @
    + rec.head.len()
    + 1 // newline
    + rec.seq.len()
    + 1 // newline
    + 2 // + and newline (WRONG!)
    + rec.qual.len()
    + 1; // newline
```

This assumed the + line was always exactly 2 bytes (`+\n`), but FASTQ format allows comments:
```
@read1
ACGT
+this is a comment
IIII
```

## Solution

Use seq_io's `write_unchanged()` method to write each record to a `ByteCountingWriter`, which accurately measures the true byte size including any separator line content.

## Test plan

- [x] Added `test_from_reader_tracks_positions` - verifies basic byte counting
- [x] Added `test_from_reader_with_plus_comment` - verifies correct handling of + line comments
- [x] All existing tests pass
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved FASTQ indexing that captures exact byte positions when reading from streams for more accurate range calculations.

* **Chores**
  * Deprecated the legacy indexing entry point in favor of the new stream-based flow; user-facing behavior remains compatible.

* **Tests**
  * Added tests covering the new indexing path, plus-line/comment handling, and range/indexing edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->