### PR TITLE
Remove confusing BgzfIndex::num_entries field

### DIFF
--- a/src/lib/tools/bgzf_index.rs
+++ b/src/lib/tools/bgzf_index.rs
@@ -8,7 +8,6 @@ use std::{
 use crate::utils::BUFFERSIZE;
 
 pub struct BgzfIndex {
-    pub num_entries: u64,
     pub entries: Vec<BgzfIndexOffset>,
 }
 
@@ -22,16 +21,17 @@ impl BgzfIndex {
     pub fn from<P: AsRef<Path>>(gzi_index: P) -> io::Result<BgzfIndex> {
         let mut reader = BufReader::with_capacity(BUFFERSIZE, File::open(gzi_index)?);
 
-        let num_entries = reader.read_u64::<LittleEndian>()?;
+        let file_entry_count = reader.read_u64::<LittleEndian>()?;
 
+        // Prepend a synthetic zero entry for the start of the file
         let mut entries = vec![BgzfIndexOffset { compressed_offset: 0, uncompressed_offset: 0 }];
-        for _ in 0..num_entries {
+        for _ in 0..file_entry_count {
             let compressed_offset = reader.read_u64::<LittleEndian>()?;
             let uncompressed_offset = reader.read_u64::<LittleEndian>()?;
             let entry = BgzfIndexOffset { compressed_offset, uncompressed_offset };
             entries.push(entry);
         }
 
-        Ok(BgzfIndex { num_entries: num_entries + 1, entries })
+        Ok(BgzfIndex { entries })
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #19 - Remove unused and confusing `num_entries` field from `BgzfIndex`
- Rename local variable to `file_entry_count` for clarity
- Add comment explaining the synthetic zero entry

## Problem

The `num_entries` field had confusing semantics:
- Set to `file_entries + 1` to include the synthetic zero entry
- Never actually read/used anywhere in the codebase
- `entries.len()` provides the same information

## Test plan

- [x] All existing tests pass
- [x] `cargo clippy` passes
- [x] `cargo fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal index handling for improved efficiency and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->